### PR TITLE
fix: correct GitHub username in URLs (gobeumsu → GoBeromsu)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,8 +18,8 @@
         "name": "Anthropic (adapted for JNU Skillthon)",
         "email": "gobeumsu@gmail.com"
       },
-      "homepage": "https://github.com/gobeumsu/JNU-Upstage-Skillthon",
-      "repository": "https://github.com/gobeumsu/JNU-Upstage-Skillthon",
+      "homepage": "https://github.com/GoBeromsu/JNU-Upstage-Skillthon",
+      "repository": "https://github.com/GoBeromsu/JNU-Upstage-Skillthon",
       "license": "MIT",
       "keywords": ["upstage", "solar", "skill", "agent", "jnu", "skillthon"],
       "category": "productivity"

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ claude .
 Claude Code 내에서 실행:
 
 ```
-/plugin marketplace add gobeumsu/JNU-Upstage-Skillthon
+/plugin marketplace add GoBeromsu/JNU-Upstage-Skillthon
 /plugin install solar-skill-creator@solar-skill-creator
 ```
 
@@ -158,7 +158,7 @@ description: 이 스킬이 하는 일과 언제 사용해야 하는지. (WHAT + 
 
 | 문서 | 설명 |
 |------|------|
-| [solar-skill-creator Marketplace](https://github.com/gobeumsu/JNU-Upstage-Skillthon) | 이 repo — `solar-skill-creator` 마켓플레이스 |
+| [solar-skill-creator Marketplace](https://github.com/GoBeromsu/JNU-Upstage-Skillthon) | 이 repo — `solar-skill-creator` 마켓플레이스 |
 | [Claude Code Docs](https://docs.anthropic.com/en/docs/claude-code/) | Claude Code 공식 문서 (Skills, Plugins, Marketplace) |
 | [Upstage Console Docs](https://console.upstage.ai/docs) | Solar LLM, Embeddings, Document Parse API 레퍼런스 |
 


### PR DESCRIPTION
## Summary
- marketplace.json과 README.md의 GitHub URL username을 `gobeumsu` → `GoBeromsu`로 수정
- `/plugin marketplace add` 실행 시 "Repository not found" 에러 해결

## Test plan
- [ ] `/plugin marketplace add GoBeromsu/JNU-Upstage-Skillthon` 정상 동작 확인

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)