### PR TITLE
fix: remove invalid skills field from plugin.json

### DIFF
--- a/skills/solar-skill-creator/.claude-plugin/plugin.json
+++ b/skills/solar-skill-creator/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "solar-skill-creator",
   "description": "Create new skills, modify and improve existing skills powered by Upstage Solar API. Use when building AI Agent skills for JNU × Upstage Skillthon.",
-  "version": "1.0.0",
-  "skills": ["."]
+  "version": "1.0.0"
 }


### PR DESCRIPTION
## Summary
- `plugin.json`에서 `"skills": ["."]` 필드 제거
- 이 필드가 `/plugin install` 시 "skills: Invalid input" validation 에러를 유발

## Test plan
- [ ] `/plugin marketplace add GoBeromsu/JNU-Upstage-Skillthon` 정상 동작
- [ ] `/plugin install solar-skill-creator@solar-skill-creator` 정상 설치

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)