### PR TITLE
refactor(solar-skill-creator): Upstage routing, reference set, key setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/
 *.skill
 .omc/
 .omx/
+.claude/

--- a/skills/solar-skill-creator/SKILL.md
+++ b/skills/solar-skill-creator/SKILL.md
@@ -52,6 +52,15 @@ Start by understanding the user's intent. The current conversation might already
 
    If intent spans multiple capabilities, compose them as a pipeline (e.g., OCR → Document Parse → Information Extract). Confirm the mapping with the user in plain language before drafting.
 
+### Verify the API key is set
+
+Every Upstage call needs `UPSTAGE_API_KEY`. Walk the user through this before drafting runtime code:
+
+1. Issue a key at https://console.upstage.ai → API Keys.
+2. Redeem the `UPWAVE-KOH` referral code for $70 in starter credit.
+3. Copy `assets/.env.example` and fill in the issued key.
+4. Confirm `UPSTAGE_API_KEY` is exported in the environment; fail fast with a message pointing back to step 1 if missing.
+
 ### Interview and Research
 
 Proactively ask questions about edge cases, input/output formats, example files, success criteria, and dependencies. Wait to write test prompts until you've got this part ironed out.


### PR DESCRIPTION
## Summary
- Anchor `solar-skill-creator` SKILL.md as a thin Upstage capability router; prune the inherited eval scaffolding (scripts, viewer, agent prompts) that didn't fit this project's scope.
- Add a complete per-capability reference set under `references/`: chat, document-parse, OCR, information-extract, classify, embeddings — each with constraints, request/response shapes, and a live-spec fallback for unexpected errors.
- Add a 4-step "Verify the API key is set" flow before the Interview phase so generated skills never hit an opaque 401 (issue key → redeem `UPWAVE-KOH` credit → copy `assets/.env.example` → confirm env var). Implementation language stays the consuming agent's call.
- Ignore `.claude/` in `.gitignore`.

## Test plan
- [ ] `solar-skill-creator` triggers on "create a skill that uses Upstage / Solar / Document Parse / OCR" prompts.
- [ ] Routing table in SKILL.md maps user intent → correct `references/upstage-*.md` without forcing the user to learn the catalog.
- [ ] Each `references/upstage-*.md` request snippet runs against the live API with a valid `UPSTAGE_API_KEY`.
- [ ] When `UPSTAGE_API_KEY` is unset, generated skills fail fast with a message pointing to `console.upstage.ai`.
- [ ] On unexpected API errors, the agent consults the live-spec link in the SKILL.md footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)