### PR TITLE
Fix solar-skill-creator plugin packaging

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Skills for Your Daily Life — Upstage Solar API 기반 AI Agent Skill 제작 도구 (JNU Skillthon)",
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "plugins": [
     {
       "name": "solar-skill-creator",
-      "source": "./skills/solar-skill-creator",
+      "source": "./",
       "description": "Create new skills, modify and improve existing skills powered by Upstage Solar API. Use when building AI Agent skills for JNU × Upstage Skillthon.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "Anthropic (adapted for JNU Skillthon)",
         "email": "gobeumsu@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "solar-skill-creator",
   "description": "Create new skills, modify and improve existing skills powered by Upstage Solar API. Use when building AI Agent skills for JNU × Upstage Skillthon.",
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/README.md
+++ b/README.md
@@ -87,8 +87,6 @@ claude .
 
 ### 3단계 — solar-skill-creator 설치
 
-**방법 A — 마켓플레이스로 설치** (권장)
-
 Claude Code 내에서 실행:
 
 ```
@@ -96,13 +94,7 @@ Claude Code 내에서 실행:
 /plugin install solar-skill-creator@solar-skill-creator
 ```
 
-**방법 B — 로컬 직접 로드**
-
-```bash
-claude skills add skills/solar-skill-creator
-```
-
-> 설치 확인: Claude Code 내에서 `/skills` 실행 → `solar-skill-creator` 목록에 표시
+> 설치 확인: Claude Code 내에서 `/plugin list` 또는 `/skills` 실행 → `solar-skill-creator` 목록에 표시
 
 ### 4단계 — Skill 만들기
 


### PR DESCRIPTION
## Summary
- Fix `solar-skill-creator` marketplace packaging by changing the plugin source from the skill directory to the repo root (`./`).
- Bump plugin/marketplace version to `1.0.1` so users can receive the update.
- Remove README guidance for the nonexistent `claude skills add` command.

## Root cause
Claude Code discovers plugin skills relative to the plugin root. The old marketplace source (`./skills/solar-skill-creator`) made the installed plugin root contain `SKILL.md` directly, without `.claude-plugin/plugin.json` or `skills/solar-skill-creator/SKILL.md` under the plugin root.

## Validation
- `claude --version` → `2.1.129 (Claude Code)`
- `claude plugin validate .` → passed
- Isolated HOME smoke test:
  - `claude plugin marketplace add ./ --scope user` → passed
  - `claude plugin install solar-skill-creator@solar-skill-creator --scope user` → installed `1.0.1`
  - installed cache contains:
    - `.claude-plugin/plugin.json`
    - `skills/solar-skill-creator/SKILL.md`
  - `claude plugin validate <installed-cache>` → passed
- Payload denylist check → passed (`.env.example` template allowed; no real `.env`/local settings/secrets/build artifacts)
- README stale command check → no `claude skills add` references remain
- Architect review → APPROVE
- Deslop scan on changed files → no fallback-like/slop findings; no cleanup edits needed
- Post-deslop revalidation/install smoke → passed
- `claude plugin tag --dry-run .` → would create `solar-skill-creator--v1.0.1`

## Release plan
After merge, create the Claude plugin release tag reported by dry-run:

```bash
claude plugin tag . --push
```

Expected tag: `solar-skill-creator--v1.0.1`.

## Rollback
Revert this commit to restore the previous marketplace source/version/README state. If a tag was already published, follow up with a patch release or delete/deprecate the tag according to repo policy.

## Not tested
- Full interactive `/solar-skill-creator:solar-skill-creator` invocation in a live Claude Code TUI.
